### PR TITLE
Te falta limpiar el buffer en caso de excepción

### DIFF
--- a/tema_11/p11_6/Mainp11_6.java
+++ b/tema_11/p11_6/Mainp11_6.java
@@ -27,6 +27,7 @@ public class Mainp11_6 {
                  opcion = dato.nextInt();
              } catch (Exception e) {
                  System.out.println("Dato introducido no valido");
+                 dato.nextLine(); // Limpiamos el buffer
              }
 
              //Lo que esta aqui debajo comentado es la solucion que me dio chatGPT pero que no entiendo 


### PR DESCRIPTION
Te faltaba limpiar el buffer en caso de que introduzcas algo que no sea un int.
El scanner utiliza un buffer interno. Si no consumes los caracteres erróneos que introduzcas, la siguiente vez que le pidas un entero con nextInt(), va a volver a intentar parsear un entero a partir de la cadena que introdujiste y que no limpiaste del buffer.